### PR TITLE
Fix error occurring due to bad json formatting.

### DIFF
--- a/lib/rate_limiting.rb
+++ b/lib/rate_limiting.rb
@@ -25,7 +25,7 @@ class RateLimiting
   def rate_limit_exceeded(accept)
     case accept.gsub(/;.*/, "").split(',')[0]
     when "text/xml"         then message, type  = xml_error("403", "Rate Limit Exceeded"), "text/xml"
-    when "application/json" then  message, type  = ["Rate Limit Exceeded"].to_json, "application/json"
+    when "application/json" then  message, type  = ["Rate Limit Exceeded"], "application/json"
     else
       message, type  = ["Rate Limit Exceeded"], "text/html"
     end

--- a/spec/json_request_spec.rb
+++ b/spec/json_request_spec.rb
@@ -1,9 +1,12 @@
 require 'spec_helper'
 
-describe "json request" do
+describe 'json request' do
   include Rack::Test::Methods
+
   it 'should receive allowed' do
-    2.times { get '/json', {}, {'HTTP_ACCEPT' => "application/json"} }
-    expect(last_response.content_type).to eq "application/json"
+    2.times { get '/json', {}, {'HTTP_ACCEPT' => 'application/json'} }
+
+    expect(last_response.content_type).to eq 'application/json'
+    expect(last_response.body).to eq 'Rate Limit Exceeded'
   end
 end


### PR DESCRIPTION
**Issue**
The `.to_json` method on the message array was producing invalid json, resulting in a `SyntaxError`.

**To reproduce**
Exceed the maximum allowed requests to an endpoint which has rate limiting, ensuring that you have the `'Accept': 'application/json'` header in the request.