### PR TITLE
feature/allow-rules-by-request-method

### DIFF
--- a/lib/rate_limiting.rb
+++ b/lib/rate_limiting.rb
@@ -104,7 +104,7 @@ class RateLimiting
 
   def find_matching_rule(request)
     @rules.each do |rule|
-      return rule if request.path =~ rule.match
+      return rule if request.path =~ rule.match && (rule.request_method == :all || request.request_method == rule.request_method.to_s.upcase)
     end
     nil
   end

--- a/lib/rule.rb
+++ b/lib/rule.rb
@@ -3,6 +3,7 @@ class Rule
   def initialize(options)
     default_options = {
       :match => /.*/,
+      :request_method => :all,
       :metric => :rph,
       :type => :frequency,
       :limit => 100,
@@ -16,6 +17,10 @@ class Rule
 
   def match
     @options[:match].class == String ? Regexp.new(@options[:match] + "$") : @options[:match]
+  end
+
+  def request_method
+    @options[:request_method] || :all
   end
 
   def limit


### PR DESCRIPTION
Add "request_method" option to rule so that rate limit rules can be applied to (for example) POST requests only.

This means we can limit POSTs to (e.g.) /users/login, without limiting (or with a different limit to) GETs from /users/login.